### PR TITLE
Fix undesired forward in waterfall

### DIFF
--- a/Node/core/src/dialogs/DialogAction.ts
+++ b/Node/core/src/dialogs/DialogAction.ts
@@ -143,7 +143,7 @@ export function waterfall(steps: IDialogWaterfallStep[]): IDialogHandler<any> {
     return function waterfallAction(s: ses.Session, r: dlg.IDialogResult<any>) {
         var skip = (result?: dlg.IDialogResult<any>) => {
             result = result || <any>{};
-            if (!result.resumed) {
+            if (result.resumed == null) {
                 result.resumed = dlg.ResumeReason.forward;
             }
             waterfallAction(s, result);


### PR DESCRIPTION
When compiling typescipt, the `ResumeReason.completed` enum evals to `0`
```js
    ResumeReason[ResumeReason["completed"] = 0] = "completed";
```

which is a falsy value. Therefore, any waterfall step that users want to mark as `complete` by using the `next|skip` callback, are automatically marked as `forward` 

Fixes #883
